### PR TITLE
Change the prefix of the image name in the 'rename' volume removal strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ rbd ls default
 * DEFAULT\_IMAGE\_SIZE - default image size for newly created images. maybe overridden by opt
 * DEFAULT\_IMAGE\_FS - default image filesystem for newly created images. maybe overridden by opt
 * DEFAULT\_IMAGE\_FEATURES - default image features for newly created images. maybe overridden by opt
-* VOLUME\_REMOVE\_ACTION - 'ignore': does nothing on Ceph Cluster when a volume is deleted; 'delete': deletes the corresponding image from Ceph Cluster (irreversible!); 'rename' - renames the corresponding Ceph Image to zz_[image name]
+* VOLUME\_REMOVE\_ACTION - 'ignore': does nothing on Ceph Cluster when a volume is deleted; 'delete': deletes the corresponding image from Ceph Cluster (irreversible!); 'rename' - renames the corresponding Ceph Image to trash_[incremental counter]_[image name]
 * DEFAULT\_POOL\_NAME - default pool name when not specified in volume name
 * DEFAULT\_POOL\_CREATE - whatever during plugin initialization, it will look for the default pool and create it or not
 * DEFAULT\_POOL\_PG_NUM - number of PGs for the default pool when creating it

--- a/cepher/driver_test.go
+++ b/cepher/driver_test.go
@@ -84,7 +84,7 @@ func TestListCommand(t *testing.T) {
 	}
 	logrus.Debug(*response)
 
-	// Start 6 cicles of Create/Mount/Unmount/Remove Images from Ceph
+	// Start 6 cycles of Create/Mount/Unmount/Remove Images from Ceph
 	wg.Add(6)
 	go DoCompleteTask("volumes/test-1", driver)
 	go DoCompleteTask("volumes/test-2", driver)
@@ -99,29 +99,29 @@ func TestListCommand(t *testing.T) {
 
 func DoCompleteTask(imageName string, driver cephRBDVolumeDriver) {
 	defer wg.Done()
-	logrus.Debugf("Inciado %s", imageName)
+	logrus.Debugf("Starting %s", imageName)
 
 	//# Create Requests to Call at the same format received from docker volumes interface
 	var reqCreate volume.CreateRequest
 	reqCreate.Name = imageName
 	var reqMount volume.MountRequest
 	reqMount.Name = imageName
-	var reqUmount volume.UnmountRequest
-	reqUmount.Name = imageName
+	var reqUnmount volume.UnmountRequest
+	reqUnmount.Name = imageName
 	var reqRemove volume.RemoveRequest
 	reqRemove.Name = imageName
 
 	err := driver.Create(&reqCreate)
 	if err != nil {
 		logrus.Debugf("Error at Create Image")
-		// panic("Erro at Create Image")
+		// panic("Error at Create Image")
 	}
 	logrus.Debugf("Image created %s", imageName)
 
 	response, err := driver.Mount(&reqMount)
 	if err != nil {
-		logrus.Debugf("Erro at Mount Image")
-		panic("Erro at mount image")
+		logrus.Debugf("Error at Mount Image")
+		panic("Error at mount image")
 	}
 	logrus.Debugf("Image mounted Name: %s %s", imageName, response)
 
@@ -135,12 +135,12 @@ func DoCompleteTask(imageName string, driver cephRBDVolumeDriver) {
 
 	time.Sleep(10 * time.Second)
 
-	err = driver.Unmount(&reqUmount)
+	err = driver.Unmount(&reqUnmount)
 	if err != nil {
-		logrus.Debugf("Erro at Umount Image")
-		panic("Erro at umount image")
+		logrus.Debugf("Error at Unmount Image")
+		panic("Error at unmount image")
 	}
-	logrus.Debugf("Image umounted %s", imageName)
+	logrus.Debugf("Image unmounted %s", imageName)
 
 	err = driver.Remove(&reqRemove)
 	if err != nil {

--- a/cepher/driver_test.go
+++ b/cepher/driver_test.go
@@ -144,8 +144,8 @@ func DoCompleteTask(imageName string, driver cephRBDVolumeDriver) {
 
 	err = driver.Remove(&reqRemove)
 	if err != nil {
-		logrus.Debugf("Erro at Remove Image")
-		panic("Erro at Remove image")
+		logrus.Debugf("Error at Remove Image")
+		panic("Error at Remove image")
 	}
 	logrus.Debugf("Image removed %s", imageName)
 

--- a/cepher/main.go
+++ b/cepher/main.go
@@ -27,7 +27,7 @@ func main() {
 	defaultImageSizeMB := flag.Int("size", 3*1024, "RBD Image size to Create (in MB) (default: 3072=3GB)")
 	defaultImageFSType := flag.String("fs", "xfs", "FS type for the created RBD Image (must have mkfs.type)")
 	defaultImageFeatures := flag.String("features", "layering,stripping,exclusive-lock,object-map", "Initial RBD Image features for new images")
-	defaultRemoveAction := flag.String("remove-action", "rename", "Action to be performed when receiving a command to 'remove' a volume. Options are: 'ignore' (won't remove image from Ceph), 'delete' (will delete image from Ceph - irreversible!) or 'rename' (rename image prefixing it by 'zz_')")
+	defaultRemoveAction := flag.String("remove-action", "rename", "Action to be performed when receiving a command to 'remove' a volume. Options are: 'ignore' (won't remove image from Ceph), 'delete' (will delete image from Ceph - irreversible!) or 'rename' (renames the corresponding Ceph Image to trash_[incremental counter]_[image name])")
 	useRBDKernelModule := flag.Bool("kernel-module", false, "If true, will use the Linux Kernel RBD module for mapping Ceph Images to block devices, which has greater performance, but currently supports only features 'layering', 'striping' and 'exclusive-lock'. Else, use rbd-nbd Ceph library (apt-get install rbd-nbd) which supports all Ceph image features available")
 	lockEtcdServers := flag.String("lock-etcd", "", "ETCD server addresses used for distributed lock management. ex.: 192.168.1.1:2379,192.168.1.2:2379")
 	lockTimeoutMillis := flag.Uint64("lock-timeout", 10*1000, "If a host with a mounted device stops sending lock refreshs, it will be release to another host to mount the image after this time")

--- a/cepher/utils.go
+++ b/cepher/utils.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os/exec"
 	"os/user"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -87,8 +88,6 @@ func ShWithTimeout(howLong time.Duration, name string, args ...string) (string, 
 	case <-time.After(howLong):
 		return "", ShTimeoutError{timeout: howLong}
 	}
-
-	return "", nil
 }
 
 // grepLines pulls out lines that match a string (no regex ... yet)
@@ -167,4 +166,27 @@ func GetCmdOutput(cmd *cmd.Cmd) string {
 		}
 	}
 	return out
+}
+
+func GenerateImageBackupName(name string, nameList []string) (string, error) {
+	backupPrefix := "trash"
+	count := 0
+	backupNamePattern, err := regexp.Compile(fmt.Sprintf("^%s_([0-9]{1,3})_%s$", backupPrefix, name))
+	if err != nil {
+		return "", err
+	}
+	for _, imageName := range nameList {
+		submatch := backupNamePattern.FindStringSubmatch(imageName)
+		//Full match and group 1 are returned if matched
+		if len(submatch) == 2 {
+			backupNumber, err := strconv.Atoi(submatch[1])
+			if err != nil {
+				return "", err
+			}
+			if backupNumber >= count {
+				count = backupNumber + 1
+			}
+		}
+	}
+	return fmt.Sprintf("%s_%d_%s", backupPrefix, count, name), nil
 }

--- a/cepher/utils.go
+++ b/cepher/utils.go
@@ -168,7 +168,7 @@ func GetCmdOutput(cmd *cmd.Cmd) string {
 	return out
 }
 
-func GenerateImageBackupName(name string, nameList []string) (string, error) {
+func generateImageBackupName(name string, nameList []string) (string, error) {
 	backupPrefix := "trash"
 	count := 0
 	backupNamePattern, err := regexp.Compile(fmt.Sprintf("^%s_([0-9]{1,3})_%s$", backupPrefix, name))

--- a/cepher/utils_test.go
+++ b/cepher/utils_test.go
@@ -32,3 +32,74 @@ func TestExecuteCommandDefaultTimeout(t *testing.T) {
 		fmt.Println(test)
 	}
 }
+
+func TestGenerateImageBackupName(t *testing.T) {
+	type args struct {
+		name     string
+		nameList []string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "first time backup name",
+			args: args{
+				"image-name",
+				[]string{"trash_0_another-image-name", "image-name"},
+			},
+			want:    "trash_0_image-name",
+			wantErr: false,
+		},
+		{
+			name: "nil image names",
+			args: args{
+				"image-name",
+				nil,
+			},
+			want:    "trash_0_image-name",
+			wantErr: false,
+		},
+		{
+			name: "second backup name",
+			args: args{
+				"image-name",
+				[]string{"trash_0_image-name"},
+			},
+			want:    "trash_1_image-name",
+			wantErr: false,
+		},
+		{
+			name: "multiples existent backups",
+			args: args{
+				"image-name",
+				[]string{"image-name", "trash_0_image-name", "trash_0_other-name", "trash_1_image-name", "trash_2_image-name", "trash_3_image-name", "trash_3_other-name"},
+			},
+			want:    "trash_4_image-name",
+			wantErr: false,
+		},
+		{
+			name: "always increment the counter from the highest number founded",
+			args: args{
+				"image-name",
+				[]string{"trash_22_image-name", "trash_17_image-name", "trash_3_image-name", "trash_18_image-name"},
+			},
+			want:    "trash_23_image-name",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := GenerateImageBackupName(tt.args.name, tt.args.nameList)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("GenerateImageBackupName() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("GenerateImageBackupName() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cepher/utils_test.go
+++ b/cepher/utils_test.go
@@ -92,7 +92,7 @@ func TestGenerateImageBackupName(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got, err := GenerateImageBackupName(tt.args.name, tt.args.nameList)
+			got, err := generateImageBackupName(tt.args.name, tt.args.nameList)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GenerateImageBackupName() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/test/README.md
+++ b/test/README.md
@@ -25,7 +25,7 @@ HOST_IP=XXX.XXX.XXX.XXX docker-compose -f docker-compose.ceph.yml up -d
 3. Run the shell script *run-test.sh* with the command:
 
 ```
-bash run-test.sh
+HOST_IP=XXX.XXX.XXX.XXX bash run-test.sh
 ```
 
 This shell script will create a container with the an ceph-client and will execute:

--- a/test/docker-compose.ceph.yml
+++ b/test/docker-compose.ceph.yml
@@ -11,7 +11,7 @@ services:
 
   mon1:
     image: flaviostutz/ceph-monitor:13.2.5
-    restart: always
+    restart: on-failure
     network_mode: host
     pid: host
     environment:
@@ -25,7 +25,7 @@ services:
     image: flaviostutz/ceph-manager:13.2.5
     pid: host
     network_mode: host
-    restart: always
+    restart: on-failure
     environment:
       - MONITOR_HOSTS=${HOST_IP}:6789
       - ETCD_URL=http://${HOST_IP}:12379

--- a/test/run-test.sh
+++ b/test/run-test.sh
@@ -14,4 +14,4 @@ echo "Build the images.."
 docker-compose build
 
 echo "Running test.."
-HOST_IP=172.20.10.10 docker-compose up
+docker-compose up


### PR DESCRIPTION
Adds prefix with an incremental counter to the image name when using the 'rename' volume removal strategy.

Backup name pattern: `[pool name]/trash_[counter]_[image name]`

e.g:
```
➜ docker volume ls
  DRIVER              VOLUME NAME
  cepher:latest       volumes/data

➜ docker volume rm volumes/data

➜ docker volume ls
  DRIVER              VOLUME NAME
  cepher:latest       volumes/trash_0_data
```

If volume with name `volumes/trash_0_data` already exists cepher will rename the volume to `volumes/trash_1_data` just incrementing the counter.

e.g:
```
➜ docker volume ls
  DRIVER              VOLUME NAME
  cepher:latest       volumes/data
  cepher:latest       volumes/trash_0_data

➜ docker volume rm volumes/data

➜ docker volume ls
  DRIVER              VOLUME NAME
  cepher:latest       volumes/trash_0_data
  cepher:latest       volumes/trash_1_data
```
