### PR TITLE
Returns the correct image creation timestamp on Get volume function

### DIFF
--- a/cepher/driver.go
+++ b/cepher/driver.go
@@ -1604,6 +1604,7 @@ func (d *cephRBDVolumeDriver) currentVolumes() (map[string]*Volume, error) {
 	return volumes, nil
 }
 
+// CreatedAt format image CreateTimestamp to plugin time layout
 func (i *imageInfo) CreatedAt() (string, error) {
 	parse, err := time.Parse("Mon Jan 2 15:04:05 2006", i.CreateTimestamp)
 	if err != nil {

--- a/cepher/driver.go
+++ b/cepher/driver.go
@@ -686,7 +686,7 @@ func (d *cephRBDVolumeDriver) Get(r *volume.GetRequest) (*volume.GetResponse, er
 	d.m.Lock()
 	defer d.m.Unlock()
 	logrus.Infof("")
-	logrus.Infof(">>> DOCKER API GET(%s", r)
+	logrus.Infof(">>> DOCKER API GET(%s)", r)
 	return d.GetInternal(r)
 }
 
@@ -756,7 +756,7 @@ func (d *cephRBDVolumeDriver) GetInternal(r *volume.GetRequest) (*volume.GetResp
 //
 func (d *cephRBDVolumeDriver) Path(r *volume.PathRequest) (*volume.PathResponse, error) {
 	logrus.Infof("")
-	logrus.Infof(">>> DOCKER API PATH(%s", r)
+	logrus.Infof(">>> DOCKER API PATH(%s)", r)
 	return d.PathInternal(r)
 }
 

--- a/cepher/driver.go
+++ b/cepher/driver.go
@@ -568,7 +568,7 @@ func (d *cephRBDVolumeDriver) lockMountVolume(pool, name string, readonly bool, 
 			logrus.Debugf("got RLock for mount %s", name)
 		} else {
 			if err := mutex.RWLock(ctx); err != nil {
-				logrus.Debugf("error getting mount write lock for volume %s caller ID %s lease ID %: %s", volumeName, callerID, d.etcdLockSession.Lease(), err.Error())
+				logrus.Debugf("error getting mount write lock for volume %s caller ID %s lease ID %x: %s", volumeName, callerID, d.etcdLockSession.Lease(), err.Error())
 				return err
 			}
 			logrus.Debugf("got RWLock for mount %s", name)

--- a/cepher/driver.go
+++ b/cepher/driver.go
@@ -731,8 +731,13 @@ func (d *cephRBDVolumeDriver) GetInternal(r *volume.GetRequest) (*volume.GetResp
 		return nil, errors.New(err)
 	}
 
-	//TODO verify if got error always retuning a mountpoint or It must returns mountpoint only for mounted volumes
-	return &volume.GetResponse{Volume: &volume.Volume{Name: r.Name, Mountpoint: d.mountpoint(pool, name, readonly), CreatedAt: createdAt}}, nil
+	// only provide mountPoint for volumes that are actually mounted
+	var mountPoint string
+	if d.mountLocksCount(pool, name) > 0 {
+		mountPoint = d.mountpoint(pool, name, readonly)
+	}
+
+	return &volume.GetResponse{Volume: &volume.Volume{Name: r.Name, Mountpoint: mountPoint, CreatedAt: createdAt}}, nil
 }
 
 // Path returns the path to host directory mountpoint for volume.

--- a/cepher/driver_test.go
+++ b/cepher/driver_test.go
@@ -286,7 +286,7 @@ func RenameActionTest(imageName string, driver cephRBDVolumeDriver) {
 	logrus.Debugf("Image removed %s", imageName)
 
 	//retrieve backup image name to delete permanently
-	pool, parsedName, _, err := driver.parseImagePoolName(imageName)
+	pool, parsedName, _, _, err := driver.parseImagePoolName(imageName)
 	if err != nil {
 		logrus.Debugf("Error at Remove Image - parseImagePoolName %s: %s", imageName, err.Error())
 		panic("Error at Remove image - parseImagePoolName")
@@ -305,7 +305,7 @@ func RenameActionTest(imageName string, driver cephRBDVolumeDriver) {
 }
 
 func AutoCreatePoolsTest(imageName string, driver cephRBDVolumeDriver) {
-	pool, _, _, err := driver.parseImagePoolName(imageName)
+	pool, _, _, _, err := driver.parseImagePoolName(imageName)
 	if err != nil {
 		logrus.Debugf("Error at AutoCreatePoolsTest - parseImagePoolName %s: %s", imageName, err.Error())
 		panic("Error at AutoCreatePoolsTest - parseImagePoolName")


### PR DESCRIPTION

- fixes #12 

- When inspecting a volume the field `Mountpoint` will be returned only when the volume is already mounted on the host.

e.g
Inspecting a volume mounted on the current host
```bash
$ docker inspect volumes/bindman-data
[
    {
        "CreatedAt": "2019-09-03T21:24:42Z",
        "Driver": "cepher:latest",
        "Labels": {
            "com.docker.stack.namespace": "reverse-proxy"
        },
        "Mountpoint": "/mnt/cepher/volumes/bindman-data:rw",
        "Name": "volumes/bindman-data",
        "Options": {
            "size": "5000"
        },
        "Scope": "global"
    }
]
```

Inspecting a volume mounted in another host
```bash
$ docker inspect volumes/consul-data
[
    {
        "CreatedAt": "2019-09-03T21:24:48Z",
        "Driver": "cepher:latest",
        "Labels": null,
        "Mountpoint": "",
        "Name": "volumes/consul-data",
        "Options": null,
        "Scope": "global"
    }
]
```